### PR TITLE
Add action type for set key created saga action

### DIFF
--- a/src/saga/inject-to-component.js
+++ b/src/saga/inject-to-component.js
@@ -9,6 +9,8 @@ import { getCache } from 'kea'
 
 const DEBUG = false
 
+const setKeyAction = '@@kea/set key'
+
 export default function injectSagasIntoClass (Klass, input, output) {
   const connectedActions = output.connected ? output.connected.actions : {}
 
@@ -68,6 +70,7 @@ export default function injectSagasIntoClass (Klass, input, output) {
           sagaActions[actionKey] = (...args) => {
             const createdAction = output.actions[actionKey](...args)
             return Object.assign({}, createdAction, {
+              type: createdAction.type || setKeyAction,
               payload: Object.assign({ key: key }, createdAction.payload)
             })
           }


### PR DESCRIPTION
The aim of this PR is to prevent the following error happening when creating function components connected by kea and using a `key`

![image](https://user-images.githubusercontent.com/339539/44669814-30098700-aa4b-11e8-90e5-63477fb5cfa5.png)
