### PR TITLE
sagaWrap all the sagas not just start and stop

### DIFF
--- a/src/saga/create-saga.js
+++ b/src/saga/create-saga.js
@@ -55,7 +55,7 @@ export function createSaga (logic, input, useLegacyUnboundActions = true) {
 
       if (logic.connectedSagas) {
         for (let saga of logic.connectedSagas) {
-          workers.push(yield fork(saga))
+          workers.push(yield fork(sagaWrap(saga)))
         }
       }
 


### PR DESCRIPTION
Hey @mariusandra, I'm using the `.sagas` array and need access to the logic so I went digging around and found you were binding context for the named `.start` and `.stop` sagas but not for those connected via `.sagas`. I'm running with this change now and it's working, and all tests pass so hopefully this was just an oversight and not a design decision :)